### PR TITLE
Slide in docked sidebar on first load

### DIFF
--- a/dist-modules/sidebar.js
+++ b/dist-modules/sidebar.js
@@ -253,7 +253,8 @@ var Sidebar = (function (_React$Component) {
       } else if (this.props.docked) {
 
         // show sidebar
-        sidebarStyle = update(sidebarStyle, { $merge: {
+        if (this.state.sidebarWidth !== 0)
+          sidebarStyle = update(sidebarStyle, { $merge: {
             transform: 'translateX(0%)',
             WebkitTransform: 'translateX(0%)' } });
 

--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -230,9 +230,10 @@ class Sidebar extends React.Component {
     } else if (this.props.docked) {
 
       // show sidebar
-      sidebarStyle = update(sidebarStyle, {$merge: {
-        transform: `translateX(0%)`,
-        WebkitTransform: `translateX(0%)`,
+      if (this.state.sidebarWidth !== 0)
+        sidebarStyle = update(sidebarStyle, {$merge: {
+          transform: `translateX(0%)`,
+          WebkitTransform: `translateX(0%)`,
       }});
 
       // make space on the left size of the sidebar


### PR DESCRIPTION
The sidebar width is zero in this.state when the sidebar is first rendered. When the size is then set the sidebar jumps out as the x-transform has already been set to 0%. 
With this change the transform is only applied when the width is non-zero, so the sliding-in animation correctly appears.
