### PR TITLE
fixed iOS Safari flickering issue

### DIFF
--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -11,6 +11,7 @@ const defaultStyles = {
     right: 0,
     bottom: 0,
     overflow: 'hidden',
+    WebkitTapHighlightColor: 'rgba(0,0,0,0)'
   },
   sidebar: {
     zIndex: 2,


### PR DESCRIPTION
When you tab outside of the sidebar in iOS Safari, whole page is covered grey.

This is very annoying and should be erased by default. So I propose this.