### PR TITLE
Add 'currentPathname' props.

### DIFF
--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -91,6 +91,12 @@ class Sidebar extends React.Component {
     }
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (this.props.open && this.props.currentPathname != nextProps.currentPathname) {
+      this.props.onSetOpen(false);
+    }
+  }
+
   onTouchStart(ev) {
     // filter out if a user starts swiping with a second finger
     if (!this.isTouching()) {
@@ -384,6 +390,9 @@ Sidebar.propTypes = {
 
   // callback called when the overlay is clicked
   onSetOpen: React.PropTypes.func,
+
+  // current pathname from react-router
+  currentPathname: React.PropTypes.string,
 };
 
 Sidebar.defaultProps = {


### PR DESCRIPTION
 - I added `currentPathname` props to close sidebar when screen was changed using `react-router`
     - When using `Link` tag of `react-router`, if screen was changed also changed `pathname`
 - example
    ```
      <Sidebar sidebar={sidebar}
            open={this.state.isSidebarOpen}
            onSetOpen={this.onSetSidebarOpen}
            currentPathname={this.props.location.pathname} >
      ```
      ```
        import { Link } from 'react-router';

        <Link to={`/`}>Index</Link>
        <Link to={`/about`}>About</Link>
      ```
- `this.props.location.pathname` is a property of 'react-router'