### PR TITLE
Replace findDOMNode by ref callback

### DIFF
--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -188,7 +188,7 @@ class Sidebar extends React.Component {
   }
 
   saveSidebarRef(node) {
-    this.sidebar = node; 
+    this.sidebar = node;
   }
 
   // calculate the sidebarWidth based on current touch info

--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -76,6 +76,8 @@ class Sidebar extends React.Component {
     this.onScroll = this.onScroll.bind(this);
   }
 
+  saveSidebarRef = (node) => this.sidebar = node;
+
   componentDidMount() {
     this.setState({
       dragSupported: typeof window === 'object' && 'ontouchstart' in window,
@@ -179,7 +181,7 @@ class Sidebar extends React.Component {
   }
 
   saveSidebarWidth() {
-    const width = this.refs.sidebar.offsetWidth;
+    const width = this.sidebar.offsetWidth;
 
     if (width !== this.state.sidebarWidth) {
       this.setState({sidebarWidth: width});
@@ -311,7 +313,7 @@ class Sidebar extends React.Component {
 
     return (
       <div {...rootProps}>
-        <div className={this.props.sidebarClassName} style={sidebarStyle} ref="sidebar">
+        <div className={this.props.sidebarClassName} style={sidebarStyle} ref={this.saveSidebarRef}>
           {this.props.sidebar}
         </div>
         <div className={this.props.overlayClassName}

--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 
 const CANCEL_DISTANCE_ON_SCROLL = 20;
 
@@ -313,7 +312,7 @@ class Sidebar extends React.Component {
     return (
       <div {...rootProps}>
         <div className={this.props.sidebarClassName} style={sidebarStyle}
-          ref={node => this.sidebar = node}>
+             ref={node => (this.sidebar = node)}>
           {this.props.sidebar}
         </div>
         <div className={this.props.overlayClassName}

--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -179,7 +179,7 @@ class Sidebar extends React.Component {
   }
 
   saveSidebarWidth() {
-    const width = this.sidebar.offsetWidth;
+    const width = this.refs.sidebar.offsetWidth;
 
     if (width !== this.state.sidebarWidth) {
       this.setState({sidebarWidth: width});
@@ -311,8 +311,7 @@ class Sidebar extends React.Component {
 
     return (
       <div {...rootProps}>
-        <div className={this.props.sidebarClassName} style={sidebarStyle}
-             ref={node => (this.sidebar = node)}>
+        <div className={this.props.sidebarClassName} style={sidebarStyle} ref="sidebar">
           {this.props.sidebar}
         </div>
         <div className={this.props.overlayClassName}

--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -180,7 +180,7 @@ class Sidebar extends React.Component {
   }
 
   saveSidebarWidth() {
-    const width = ReactDOM.findDOMNode(this.refs.sidebar).offsetWidth;
+    const width = this.sidebar.offsetWidth;
 
     if (width !== this.state.sidebarWidth) {
       this.setState({sidebarWidth: width});
@@ -312,7 +312,8 @@ class Sidebar extends React.Component {
 
     return (
       <div {...rootProps}>
-        <div className={this.props.sidebarClassName} style={sidebarStyle} ref="sidebar">
+        <div className={this.props.sidebarClassName} style={sidebarStyle}
+          ref={node => this.sidebar = node}>
           {this.props.sidebar}
         </div>
         <div className={this.props.overlayClassName}

--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -74,9 +74,8 @@ class Sidebar extends React.Component {
     this.onTouchMove = this.onTouchMove.bind(this);
     this.onTouchEnd = this.onTouchEnd.bind(this);
     this.onScroll = this.onScroll.bind(this);
+    this.saveSidebarRef = this.saveSidebarRef.bind(this);
   }
-
-  saveSidebarRef = (node) => this.sidebar = node;
 
   componentDidMount() {
     this.setState({
@@ -186,6 +185,10 @@ class Sidebar extends React.Component {
     if (width !== this.state.sidebarWidth) {
       this.setState({sidebarWidth: width});
     }
+  }
+
+  saveSidebarRef(node) {
+    this.sidebar = node; 
   }
 
   // calculate the sidebarWidth based on current touch info


### PR DESCRIPTION
Hi @balloob,

This PR is to remove the call to `findDOMNode`, because the use of this function is discouraged.
Instead I used a ref callback (available since react@0.13: https://twitter.com/dan_abramov/status/584125325212307456?lang=en).

(My initial need is for snapshot testing with jest: https://github.com/facebook/react/pull/8989)

Thanks!