### PR TITLE
Modify sidebar content styles to include momentum scrolling on mobile devices

### DIFF
--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -27,7 +27,8 @@ const defaultStyles = {
     left: 0,
     right: 0,
     bottom: 0,
-    overflow: 'auto',
+    overflowY: 'scroll',
+    WebkitOverflowScrolling: 'touch',
     transition: 'left .3s ease-out, right .3s ease-out',
   },
   overlay: {


### PR DESCRIPTION
fixes #41 
https://css-tricks.com/snippets/css/momentum-scrolling-on-ios-overflow-elements/