### PR TITLE
update prop-types to be a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "license": "MIT",
   "peerDependencies": {
     "react": ">=0.14.0",
-    "react-dom": ">=0.14.0"
+    "react-dom": ">=0.14.0",
+    "prop-types": ">=15.5.0"
   },
   "devDependencies": {
     "babel-cli": "^6.3.17",
@@ -36,7 +37,6 @@
     "eslint": "<2.3.0",
     "eslint-config-airbnb": "^2.1.1",
     "eslint-plugin-react": "^3.13.1",
-    "prop-types": "^15.5.4",
     "react": ">=0.14.0",
     "react-dom": ">=0.14.0",
     "webpack": "^1.12.9",


### PR DESCRIPTION
Prop-Types was not a peer dependency. See: https://facebook.github.io/react/docs/typechecking-with-proptypes.html

#106