### PR TITLE
Add ability to pass 'id' attribute for content

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Supported props
 | sidebarClassName | string | n/a | Add a custom class to the sidebar |
 | contentClassName | string | n/a | Add a custom class to the content |
 | overlayClassName | string | n/a | Add a custom class to the overlay |
+| contentID        | string | n/a | Add a custon ID to the content |
 | sidebar | Anything React can render | n/a | The sidebar content |
 | onSetOpen | function | n/a | Callback called when the sidebar wants to change the open prop. Happens after sliding the sidebar and when the overlay is clicked when the sidebar is open. |
 | docked | boolean | false | If the sidebar should be always visible |

--- a/dist-modules/sidebar.js
+++ b/dist-modules/sidebar.js
@@ -379,7 +379,7 @@ var Sidebar = function (_Component) {
         }),
         _react2.default.createElement(
           'div',
-          { className: this.props.contentClassName, style: contentStyle },
+          { className: this.props.contentClassName, style: contentStyle, id: this.props.contentID },
           dragHandle,
           this.props.children
         )
@@ -411,6 +411,9 @@ Sidebar.propTypes = {
 
   // content optional class
   contentClassName: _propTypes2.default.string,
+
+  // content optional id
+  contentID: _propTypes2.default.string,
 
   // overlay optional class
   overlayClassName: _propTypes2.default.string,

--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -328,7 +328,7 @@ class Sidebar extends Component {
              tabIndex="0"
              onClick={this.overlayClicked}
           />
-        <div className={this.props.contentClassName} style={contentStyle}>
+        <div className={this.props.contentClassName} style={contentStyle} id={this.props.contentID} >
           {dragHandle}
           {this.props.children}
         </div>
@@ -358,6 +358,9 @@ Sidebar.propTypes = {
 
   // content optional class
   contentClassName: PropTypes.string,
+
+  // content optional id
+  contentID: PropTypes.string,
 
   // overlay optional class
   overlayClassName: PropTypes.string,


### PR DESCRIPTION
This adds compatibility with react-scroll. react-scroll needs to have an id for the container element (see [example](https://github.com/fisshy/react-scroll/blob/master/examples/basic/app.js#L98))