### PR TITLE
Gitignore Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-.DS_Store
-node_modules
+.idea/
+_dev/
+node_modules/
 example/compiled
+.DS_Store
 npm-debug.log


### PR DESCRIPTION
Updated gitignore. .idea/ is for JetBrains IDEs. The / on the end of folder names is to make it explicit that they are folder names. added a _dev/ folder for personal dev stuff not meant to be checked in. Sorted ignores in the order of folder -> file with sub-order of hidden -> non-hidden.