### PR TITLE
Allow to subscribe to onScroll event of main content

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Supported props
 | pullRight | boolean | false | Place the sidebar on the right |
 | shadow | boolean | true | Enable/Disable sidebar shadow |
 | styles | object | [See below](#styles) | Inline styles. These styles are merged with the defaults and applied to the respective elements. |
+| onContentScroll | function | n/a | Callback called when main content is scrolled |
 
 Installation
 ------------

--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -328,7 +328,7 @@ class Sidebar extends Component {
              tabIndex="0"
              onClick={this.overlayClicked}
           />
-        <div className={this.props.contentClassName} style={contentStyle}>
+        <div onScroll={this.props.onContentScroll} className={this.props.contentClassName} style={contentStyle}>
           {dragHandle}
           {this.props.children}
         </div>
@@ -394,6 +394,9 @@ Sidebar.propTypes = {
 
   // Intial sidebar width when page loads
   defaultSidebarWidth: PropTypes.number,
+
+  // callback called when main content is scrolled
+  onContentScroll: PropTypes.func
 };
 
 Sidebar.defaultProps = {


### PR DESCRIPTION
Right now it's not possible to subscribe to the scroll event of the main content without resorting to DOM-level API functions.

Having a onContentScroll property in place makes it easy to implement things like parallax scrolling for the main content.