### PR TITLE
Enable window scrolling

### DIFF
--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -4,14 +4,11 @@ import PropTypes from "prop-types";
 const CANCEL_DISTANCE_ON_SCROLL = 20;
 
 const defaultStyles = {
-  root: {},
   sidebar: {
     zIndex: 2,
     position: "fixed",
     top: 0,
     height: "100vh",
-
-    // bottom: 0,
     transition: "transform .3s ease-out",
     WebkitTransition: "-webkit-transform .3s ease-out",
     willChange: "transform",
@@ -23,8 +20,6 @@ const defaultStyles = {
     left: 0,
     right: 0,
     bottom: 0,
-    // overflowY: "scroll",
-    WebkitOverflowScrolling: "touch",
     transition: "left .3s ease-out, right .3s ease-out"
   },
   overlay: {
@@ -33,7 +28,6 @@ const defaultStyles = {
     top: 0,
     left: 0,
     right: 0,
-    // bottom: 0,
     height: "100vh",
     opacity: 0,
     visibility: "hidden",
@@ -47,6 +41,29 @@ const defaultStyles = {
     bottom: 0
   }
 };
+
+let scrollTop;
+let isScrollable = true;
+
+function enableScroll() {
+  if (typeof document === "undefined") return;
+  const doc = document.documentElement;
+  doc.style.width = "";
+  doc.style.position = "";
+  doc.style.top = "";
+  window.scroll(0, scrollTop);
+  isScrollable = true;
+}
+
+function disableScroll() {
+  if (typeof document === "undefined") return;
+  const doc = document.documentElement;
+  scrollTop = window.pageYOffset;
+  doc.style.width = "100%";
+  doc.style.position = "fixed";
+  doc.style.top = `${-scrollTop}px`;
+  isScrollable = false;
+}
 
 class Sidebar extends Component {
   constructor(props) {
@@ -82,8 +99,15 @@ class Sidebar extends Component {
 
   componentDidUpdate() {
     // filter out the updates when we're touching
-    if (!this.isTouching()) {
+    const isTouching = this.isTouching();
+    if (!isTouching) {
       this.saveSidebarWidth();
+    }
+    // Disable or enable scrolling depending on state
+    if (isScrollable && (this.props.open || isTouching)) {
+      disableScroll();
+    } else if (!isScrollable && !this.props.open && !isTouching) {
+      enableScroll();
     }
   }
 
@@ -241,7 +265,7 @@ class Sidebar extends Component {
     const isTouching = this.isTouching();
     const rootProps = {
       className: this.props.rootClassName,
-      style: { ...defaultStyles.root, ...this.props.styles.root },
+      style: this.props.styles.root,
       role: "navigation"
     };
     let dragHandle;
@@ -265,8 +289,6 @@ class Sidebar extends Component {
 
     if (isTouching) {
       const percentage = this.touchSidebarWidth() / this.state.sidebarWidth;
-
-      // slide open to what we dragged
       if (this.props.pullRight) {
         sidebarStyle.transform = `translateX(${(1 - percentage) * 100}%)`;
         sidebarStyle.WebkitTransform = `translateX(${(1 - percentage) * 100}%)`;

--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -4,19 +4,14 @@ import PropTypes from "prop-types";
 const CANCEL_DISTANCE_ON_SCROLL = 20;
 
 const defaultStyles = {
-  root: {
-    position: "absolute",
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-    overflow: "hidden"
-  },
+  root: {},
   sidebar: {
     zIndex: 2,
-    position: "absolute",
+    position: "fixed",
     top: 0,
-    bottom: 0,
+    height: "100vh",
+
+    // bottom: 0,
     transition: "transform .3s ease-out",
     WebkitTransition: "-webkit-transform .3s ease-out",
     willChange: "transform",
@@ -28,7 +23,7 @@ const defaultStyles = {
     left: 0,
     right: 0,
     bottom: 0,
-    overflowY: "scroll",
+    // overflowY: "scroll",
     WebkitOverflowScrolling: "touch",
     transition: "left .3s ease-out, right .3s ease-out"
   },
@@ -38,7 +33,8 @@ const defaultStyles = {
     top: 0,
     left: 0,
     right: 0,
-    bottom: 0,
+    // bottom: 0,
+    height: "100vh",
     opacity: 0,
     visibility: "hidden",
     transition: "opacity .3s ease-out, visibility .3s ease-out",
@@ -359,7 +355,6 @@ class Sidebar extends Component {
           className={this.props.overlayClassName}
           style={overlayStyle}
           role="presentation"
-          tabIndex="0"
           onClick={this.overlayClicked}
         />
         <div className={this.props.contentClassName} style={contentStyle}>


### PR DESCRIPTION
This PR fixes most of the scrolling issues. It basically enables using the body as the scroll container instead of using the content-div as the scrolling container. This solves a few problems:

* The address bar now goes away on mobile when scrolling the main content down. Fixes #113 
* Scroll events now fire as usual. Fixes #77 

I'm not certain if I should ship this into 3.0.0 since it might break a ton of stuff, and there might be bugs on certain devices or usecases that I haven't thought of.

This PR was inspired by #86 Thanks @MilllerTime 