### PR TITLE
disable touch for ios devices

### DIFF
--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -78,8 +78,10 @@ class Sidebar extends Component {
   }
 
   componentDidMount() {
+    const isIos = /iPad|iPhone|iPod/.test(navigator ? navigator.userAgent : "");
     this.setState({
-      dragSupported: typeof window === "object" && "ontouchstart" in window
+      dragSupported:
+        typeof window === "object" && "ontouchstart" in window && !isIos
     });
     this.saveSidebarWidth();
   }


### PR DESCRIPTION
This PR completely disables all touch functionality on all IOS devices. Why? Because it wasn't working anyway due to IOS built in swipe to go back feature. This feature can't be disabled in Javascript, so this is unfortunately the best way to handle it. "Fixes" #67 